### PR TITLE
Fix the data load for index task

### DIFF
--- a/lib/services/elasticsearch/indexers/index.rb
+++ b/lib/services/elasticsearch/indexers/index.rb
@@ -1,5 +1,3 @@
-require 'sidekiq'
-
 module Elasticsearch
   class Index
     def perform(*ids)

--- a/lib/services/elasticsearch/indexers/product_record.rb
+++ b/lib/services/elasticsearch/indexers/product_record.rb
@@ -1,4 +1,4 @@
-require_relative 'index'
+require_relative './index'
 
 module Elasticsearch
   module ProductRecord

--- a/lib/services/elasticsearch/indexers/user_record.rb
+++ b/lib/services/elasticsearch/indexers/user_record.rb
@@ -1,4 +1,4 @@
-require_relative 'index'
+require_relative './index'
 
 module Elasticsearch
   module UserRecord

--- a/lib/services/elasticsearch/repository.rb
+++ b/lib/services/elasticsearch/repository.rb
@@ -44,8 +44,7 @@ module Elasticsearch
       client.index(
         index: index,
         id: id_key_for(id, type),
-        body: body,
-        type: '_doc'
+        body: body
       )
     end
 
@@ -57,7 +56,7 @@ module Elasticsearch
         id = id_key_for(item[:id], type)
 
         [
-          { index: { _index: index, _id: id, _type: '_doc' } }.to_json,
+          { index: { _index: index, _id: id } }.to_json,
           body.to_json
         ]
       end.flatten.join("\n") + "\n"
@@ -89,8 +88,7 @@ module Elasticsearch
 
       client.delete(
         index: index,
-        id: key,
-        type: '_doc'
+        id: key
       )
     rescue Elasticsearch::Transport::Transport::Errors::NotFound
       if ENV['LOG_ELASTICSEARCH_QUERIES'] == 'true' && !::Rails.env.test?

--- a/lib/tasks/recreate_indices_and_import_data_elastic.rake
+++ b/lib/tasks/recreate_indices_and_import_data_elastic.rake
@@ -1,4 +1,6 @@
 require './lib/services/elasticsearch/feed'
+require './lib/services/elasticsearch/indexers/product_record'
+require './lib/services/elasticsearch/indexers/user_record'
 desc 'Create indices and import data in Elastic Search'
 
 namespace :elastic do
@@ -18,8 +20,8 @@ namespace :elastic do
 
   task loadDataOnIndices: :environment do
     puts 'Importing data'
-    Elasticsearch::UserRecord::Index.new.perform(User.all.pluck(:id))
     Elasticsearch::ProductRecord::Index.new.perform(Product.all.pluck(:id))
+    Elasticsearch::UserRecord::Index.new.perform(User.all.pluck(:id))
     puts 'Data imported to Elastic Search'
   end
 end


### PR DESCRIPTION
Fixed the issue we were experiencing with the `recreate_indices_and_import_data_elastic` task. I think we need to require the record files as we are not using sidekiq in this implementation. Not a 100% sure on this but with the require it seems to be working just fine.